### PR TITLE
Issue -> Issues

### DIFF
--- a/lib/redmine_force_issues_private.rb
+++ b/lib/redmine_force_issues_private.rb
@@ -2,7 +2,7 @@
 
 require_dependency 'issue'
 
-module RedmineForceIssuePrivate
+module RedmineForceIssuesPrivate
   module Hooks
     class ModelIssueHook < Redmine::Hook::ViewListener
       def controller_issues_new_before_save(context={})


### PR DESCRIPTION
Resolve error with modern versions of Redmine/Ruby

```
NameError: uninitialized constant RedmineForceIssuesPrivate
Did you mean? RedmineForceIssuePrivate
```